### PR TITLE
Fix Fence blockstate caching

### DIFF
--- a/src/main/java/snownee/snow/block/ModSnowBlock.java
+++ b/src/main/java/snownee/snow/block/ModSnowBlock.java
@@ -56,6 +56,7 @@ import snownee.kiwi.tile.TextureTile;
 import snownee.snow.MainModule;
 import snownee.snow.SnowClientConfig;
 import snownee.snow.SnowCommonConfig;
+import snownee.snow.block.state.SnowFenceBlockState;
 import snownee.snow.entity.FallingSnowEntity;
 
 public class ModSnowBlock extends SnowBlock implements ISnowVariant
@@ -495,9 +496,14 @@ public class ModSnowBlock extends SnowBlock implements ISnowVariant
         }
         else if (block instanceof FenceBlock && state.getBlock() != MainModule.FENCE)
         {
+            //Cache what the material should/will be so that we can use the correct material while the state is changing
+            //Otherwise we have the issue that the tile has no data yet so we cannot use the proper value directly from the block
+            SnowFenceBlockState.setCachedMaterial(world, pos, state.getMaterial());
             BlockState newState = MainModule.FENCE.getDefaultState().with(FourWayBlock.NORTH, state.get(FourWayBlock.NORTH)).with(FourWayBlock.SOUTH, state.get(FourWayBlock.SOUTH)).with(FourWayBlock.WEST, state.get(FourWayBlock.WEST)).with(FourWayBlock.EAST, state.get(FourWayBlock.EAST));
             newState = newState.updatePostPlacement(Direction.DOWN, stateDown, world, pos, posDown);
             world.setBlockState(pos, newState, flags);
+            //Clear the temporary cache we set so that we don't have to deal with all the edge cases of when it needs to be invalidated
+            SnowFenceBlockState.clearCachedMaterial(world, pos);
         }
         else if (block instanceof FenceGateBlock && state.getBlock() != MainModule.FENCE_GATE)
         {

--- a/src/main/java/snownee/snow/block/SnowFenceBlock.java
+++ b/src/main/java/snownee/snow/block/SnowFenceBlock.java
@@ -16,9 +16,7 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
-import net.minecraft.item.BlockItem;
 import net.minecraft.item.BlockItemUseContext;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.BooleanProperty;
@@ -29,7 +27,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.Direction;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ITextComponent;
@@ -41,9 +38,7 @@ import net.minecraft.world.LightType;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.registries.ForgeRegistries;
 import snownee.kiwi.block.ModBlock;
-import snownee.kiwi.util.NBTHelper;
 import snownee.kiwi.util.Util;
 import snownee.snow.MainModule;
 import snownee.snow.SnowCommonConfig;
@@ -131,24 +126,7 @@ public class SnowFenceBlock extends FenceBlock implements ISnowVariant
         World iblockreader = context.getWorld();
         BlockPos blockpos = context.getPos();
         BlockState stateIn = iblockreader.getBlockState(blockpos);
-        BlockState state = super.getStateForPlacement(context).with(WATERLOGGED, false).with(DOWN, MainModule.BLOCK.isValidPosition(stateIn, iblockreader, blockpos));
-        if (state instanceof SnowFenceBlockState)
-        {
-            ItemStack stack = context.getItem();
-            NBTHelper data = NBTHelper.of(stack);
-            String rl = data.getString("BlockEntityTag.Items.0");
-            if (rl != null && ResourceLocation.func_217855_b(rl))
-            {
-                Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(rl));
-                if (item != null && item instanceof BlockItem)
-                {
-                    Block block = ((BlockItem) item).getBlock();
-                    Material mat = block.getDefaultState().getMaterial();
-                    ((SnowFenceBlockState) state).setMaterial(mat);
-                }
-            }
-        }
-        return state;
+        return super.getStateForPlacement(context).with(WATERLOGGED, false).with(DOWN, MainModule.BLOCK.isValidPosition(stateIn, iblockreader, blockpos));
     }
 
     @Override


### PR DESCRIPTION
This fixes #18 by only caching the material information for the duration of placing. This is before we have a tile with proper data so cannot grab the accurate information. The reason the cache gets cleared immediately after we are done setting the block is so that we do not have to keep a large cache in memory (given it could be potentially infinite), and so we don't have to deal with all the edge case invalidation if blocks get edited directly.