### PR TITLE
Copy all block state properties when replacing block with snowy variant

### DIFF
--- a/src/main/java/snownee/snow/block/SnowFenceBlock.java
+++ b/src/main/java/snownee/snow/block/SnowFenceBlock.java
@@ -90,15 +90,17 @@ public class SnowFenceBlock extends FenceBlock implements IWaterLoggableSnowVari
 
     @Override
     public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+        stateIn = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
         if (facing == Direction.DOWN) {
             return stateIn.with(DOWN, MainModule.BLOCK.isValidPosition(stateIn, worldIn, currentPos, true));
         }
-        return super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
+        return stateIn;
     }
 
     @Override
     protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(NORTH, EAST, WEST, SOUTH, DOWN, WATERLOGGED);
+        super.fillStateContainer(builder);
+        builder.add(DOWN);
     }
 
     @Override


### PR DESCRIPTION
So right now when a snow layer is placed onto a snow coverable block which is then converted to one of SnowRealMagic's own blocks, only some vanilla block state properties are copied manually.

- This PR changes this behavior in `ModSnowBlock::convert` to copy every property there is, which also enables properties added by mods (via core modding) to be copied.
- This PR also adds two super calls in `SnowFenceBlock`, which also help with mod compatibility.

Those changes where made mainly to provide compatibility with my own [Diagonal Fences](https://github.com/Fuzss/diagonalfences) mod. Both mods work really well together with those minor adjustments without needing any hardcoded compatibility. But I do also see them becoming useful with other mods.

It seems much easier to implement those changes on SnowRealMagic's side, therefore this PR.

And to close it off a screenshot of both mods in action. I think they look wonderful together! :)
![](https://i.imgur.com/VVKCdlh.png)