### PR TITLE
Serene Seasons compatibilty fix

### DIFF
--- a/src/main/java/snownee/snow/Hooks.java
+++ b/src/main/java/snownee/snow/Hooks.java
@@ -314,7 +314,7 @@ public final class Hooks {
 		}
 
 		boolean flag = false;
-		if (worldIn.isRaining() && biome.value().coldEnoughToSnow(pos)) {
+		if (worldIn.isRaining() && ModUtil.coldEnoughToSnow(worldIn, pos, biome)) {
 			if (SnowCommonConfig.snowAccumulationDuringSnowfall) {
 				flag = true;
 			} else if (SnowCommonConfig.snowAccumulationDuringSnowstorm && worldIn.isThundering()) {


### PR DESCRIPTION
With Serene Seasons installed snow was not accumulating in winter for normally rainy biomes. Fixed snow check.