### PR TITLE
Fix ClassNotFoundException when using Fancier Block Particles

### DIFF
--- a/src/main/java/snownee/snow/compat/FBPHack.java
+++ b/src/main/java/snownee/snow/compat/FBPHack.java
@@ -7,20 +7,24 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import snownee.snow.SnowRealMagic;
 
-public final class FBPHack {
-	@SubscribeEvent(priority = EventPriority.LOW)
-	public void hackFBP(WorldEvent.Load event) {
-		try {
-			Class<?> FBPClass = Class.forName("com.TominoCZ.FBP.FBP");
-			Object mod = FBPClass.getDeclaredField("INSTANCE").get(null);
-			List<String> list = (List<String>) FBPClass.getDeclaredField("blockAnimBlacklist").get(mod);
-			if (list.contains("minecraft:snow_layer"))
-				return;
-			list.add("minecraft:snow_layer");
-			Class<?> FBPConfigHandlerClass = Class.forName("com.TominoCZ.FBP.handler.FBPConfigHandler");
-			FBPConfigHandlerClass.getDeclaredMethod("writeAnimExceptions").invoke(null);
-		} catch (Throwable e) {
-			SnowRealMagic.logger.catching(e);
+	public final class FBPHack {
+		@SubscribeEvent(priority = EventPriority.LOW)
+		public void hackFBP(WorldEvent.Load event) {
+			try {
+				Class.forName("io.redstudioragnarok.FBP.FBP");
+			} catch (ClassNotFoundException e) {
+				try {
+					Class<?> FBPClass = Class.forName("com.TominoCZ.FBP.FBP");
+					Object mod = FBPClass.getDeclaredField("INSTANCE").get(null);
+					List<String> list = (List<String>) FBPClass.getDeclaredField("blockAnimBlacklist").get(mod);
+					if (list.contains("minecraft:snow_layer"))
+						return;
+					list.add("minecraft:snow_layer");
+					Class<?> FBPConfigHandlerClass = Class.forName("com.TominoCZ.FBP.handler.FBPConfigHandler");
+					FBPConfigHandlerClass.getDeclaredMethod("writeAnimExceptions").invoke(null);
+				} catch (Throwable e) {
+					SnowRealMagic.logger.catching(e);
+				}
+			}
 		}
 	}
-}


### PR DESCRIPTION
This fixes [#15] which occur since the refactoring that has happen in 0.8

If this hack is still needed, then please create an Issue on GitHub so that I can fix this properly without you needing to hack into FBP.

[#15]: https://github.com/Red-Studio-Ragnarok/Fancier-Block-Particles/issues/15