### PR TITLE
Use @Mutable to definalize the `block` field of `ItemBlock`

### DIFF
--- a/src/main/java/snownee/snow/mixin/ItemBlockAccessor.java
+++ b/src/main/java/snownee/snow/mixin/ItemBlockAccessor.java
@@ -1,6 +1,7 @@
 package snownee.snow.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import net.minecraft.block.Block;
@@ -8,6 +9,7 @@ import net.minecraft.item.ItemBlock;
 
 @Mixin(ItemBlock.class)
 public interface ItemBlockAccessor {
+	@Mutable
 	@Accessor("block")
 	void setBlock(Block block);
 }


### PR DESCRIPTION
This fixes a bug that caused Cleanroom loader to crash (and it's best practice to use @Mutable on Accessors of final fields)